### PR TITLE
PanicMatchesSkip calls FailNow() when it does not panic

### DIFF
--- a/assert.go
+++ b/assert.go
@@ -120,6 +120,9 @@ func PanicMatchesSkip(t *testing.T, skip int, fn func(), matches string) {
 				fmt.Printf("%s:%d Panic...  expected [%s] received [%s]", path.Base(file), line, matches, err)
 				t.FailNow()
 			}
+		} else {
+			fmt.Printf("Panic expected, none found, expected [%v] ", matches)
+			t.FailNow()
 		}
 	}()
 

--- a/assert_test.go
+++ b/assert_test.go
@@ -39,6 +39,11 @@ func TestBasicAllGood(t *testing.T) {
 	PanicMatches(t, func() { fn() }, "omg omg omg!")
 	PanicMatches(t, func() { panic("omg omg omg!") }, "omg omg omg!")
 
+	/* if you uncomment creates hard fail, that is expected
+	// you cant really do this, but it is here for the sake of completeness
+	fun := func() {}
+	PanicMatches(t, func() { fun() }, "omg omg omg!")
+	*/
 	errs := map[string]string{}
 	errs["Name"] = "User Name Invalid"
 	errs["Email"] = "User Email Invalid"


### PR DESCRIPTION
correct MatchesPanic not failing when no panic occurs
